### PR TITLE
fix: 🐛 Add repository details to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,9 @@
     "@polkadot/util-crypto": "13.5.9",
     "@polymeshassociation/signing-manager-types": "3.7.1"
   },
-  "packageManager": "yarn@4.14.1"
+  "packageManager": "yarn@4.14.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/PolymeshAssociation/local-signing-manager.git"
+  }
 }


### PR DESCRIPTION
### Description

With missing repository info in package json, the release to npm failed on last merge - https://github.com/PolymeshAssociation/local-signing-manager/actions/runs/24891208773/job/72883828615

### Breaking Changes

<!-- List all the breaking changes here -->

### JIRA Link

<!-- Insert JIRA issue here. Example: DA-40  -->

### Checklist

- [ ] Updated the Readme.md (if required) ?
